### PR TITLE
[UX] Eco-redesign homepage — suppression ateliers, focus data leadership

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2,6 +2,24 @@ body * {
     font-family: Arial, Helvetica, sans-serif;
 }
 
+/* Eco-UX: section separators sobres, sans surcharge visuelle */
+.post__content hr {
+    border: none;
+    border-top: 1px solid rgba(0,0,0,0.12);
+    margin: 1.2em 0;
+}
+
+/* Densité lisible sans clutter — listes serrées */
+.post__content ul {
+    margin-top: 0.4em;
+    margin-bottom: 0.4em;
+}
+
+/* Respiration après séparateur avant titre de section */
+.post__content hr + h2 {
+    margin-top: 0.5rem;
+}
+
 blockquote {
     margin-left: 10px;
     margin-right: 0px;

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,35 +8,26 @@ images:
 ---
 # Épaulons-nous
 
-Bienvenue, moi c'est Paul. Je lis des longs rapports pour que vous n'ayez pas à le faire. 
-
-### Je peux vous épauler à travers ces 3 axes
----
-## 📲 Numérique avec plus de 10 ans d'éxpériences
----
-Mon parcours va de la start-up à la scale-up en passant par des institutions bancaires dans ces domaines :
-* **Fullstack Data** : Entrepôt de données, Kafka, Spark, API, BI, LLM, Scala, Python... *(en gros, je code)*
-* [**Culture DevOps et Agile**](https://www.epauler.fr/article/la-culture-de-la-r%C3%A9silience-%C3%A0-travers-le-devops-devpo-et-devqa/) : collaboration entre équipes, automatisation, déploiement, monitoring, rétrospective *(en gros, je fais en sorte que tout se passe bien dans les équipes)*
-* **Ecoconception des services numériques** : ["Il faut que ça dure plus longtemps, on ne peut pas vivre dans un monde où les smartphones vont durer 2 à 3 ans"](https://www.linkedin.com/posts/paleclercq_mataezrialitaez-activity-7015982682203394048-kHjh)
+Paul. Je lis des longs rapports pour que vous n'ayez pas à le faire.
 
 ---
-## 📚 Formations avec plus de 300 personnes accompagnées
----
-Mes travaux pratiques en data engineering, docker, organisation, et en écoconception sont disponibles [sur ce repo GitHub.](https://github.com/polomarcus/tp)
+## 📲 10 ans de projets data, du prototype à la production
+
+De la start-up à la scale-up, des banques aux observatoires citoyens — j'ai mené des projets data complexes à leur terme :
+
+* **Architecture & delivery data** : pipelines Kafka/Spark, entrepôts de données, APIs, BI, LLM — de la conception au run en production
+* [**Culture DevOps/Agile**](https://www.epauler.fr/article/la-culture-de-la-r%C3%A9silience-%C3%A0-travers-le-devops-devpo-et-devqa/) : collaboration inter-équipes, CI/CD, monitoring, rétrospectives — parce qu'un projet qui dure, c'est d'abord une équipe qui tient
+* **Écoconception** : ["Il faut que ça dure plus longtemps"](https://www.linkedin.com/posts/paleclercq_mataezrialitaez-activity-7015982682203394048-kHjh) — moins de code, moins de serveurs, plus de sens
 
 ---
-## 📊 Ateliers scientifiques de cohésion d'équipe
----
-* **[Fresque du Climat](https://fresqueduclimat.org/)** : l'incontournable pour mieux comprendre notre économie basée les énergies fossiles avec l'aide des rapports du GIEC.
-* **[Fresque du Numérique](https://fresquedunumerique.org/)** : pour creuser les différents aspects (mines, santé mentale...) du numérique. *Spoiler: non ce n'est pas une histoire [d'email avec des pièces jointes](https://www.linkedin.com/posts/paleclercq_si-comme-la-ministre-de-la-transition-%C3%A9nerg%C3%A9tique-activity-6934784676515487745-pVeL/)*
-* **[2 Tonnes](https://www.2tonnes.org/)** : comment passer des 10 tonnes de CO2e en moyenne par Français à [2 tonnes de CO2e](https://bonpote.com/objectif-2-tonnes-vrai-defi-ou-mauvaise-cible/) en 2050 ? *Spoiler: ce n'est pas en mettant une ruche sur le toit*
+## 📚 300+ personnes formées
 
+Data engineering, Docker, organisation, écoconception — les travaux pratiques sont [sur GitHub](https://github.com/polomarcus/tp).
 
 ---
-## 📖 Quelques projets open-source
----
-* [L’Observatoire des Médias sur l’Écologie](https://observatoiremediaecologie.fr/) : avec le soutien de L'ADEME, l'ARCOM et plusieurs associations.
-* [L'observatoire des JT sur les changements climatiques](https://observatoire.climatmedias.org/) : Scrapper Scala, construit autour de la CI GitHub Actions
-* [Spark Structured Streaming examples with Kafka / Cassandra / Elastic](https://github.com/polomarcus/Spark-Structured-Streaming-Examples) : une centaine de stars GitHub pour flatter mon égo tout en servant la communauté
-* J'écris sur la tech mais pas que [ici même sur ce blog](https://www.epauler.fr/article/)
+## 📖 Projets open-source
 
+* [Observatoire des Médias sur l'Écologie](https://observatoiremediaecologie.fr/) — avec le soutien de l'ADEME, l'ARCOM et plusieurs associations
+* [Observatoire des JT sur les changements climatiques](https://observatoire.climatmedias.org/) — Scala + CI GitHub Actions
+* [Spark Structured Streaming examples](https://github.com/polomarcus/Spark-Structured-Streaming-Examples) — ~100 stars GitHub
+* J'écris sur la tech et au-delà [sur ce blog](https://www.epauler.fr/article/)


### PR DESCRIPTION
- Supprime la section "Ateliers scientifiques de cohésion d'équipe" (Fresque du Climat, Fresque du Numérique, 2 Tonnes)
- Reformule la section Numérique : focus sur le pilotage de projets data d'envergure de bout en bout (architecture, delivery, culture équipe)
- Prose plus concise, verbes d'action, sans parenthèses explicatives
- CSS : séparateurs sobres, densité liste, respiration inter-sections (éco-conception UX à la Damasio — le fond dicte la forme)

https://claude.ai/code/session_013tUJMgk3oTS4ptsnbS2pGv